### PR TITLE
Removed reference to "Hall of Fame"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Written in DocBook XML V4.5 format [DocBook](http://docbook.org/xml/4.5/docbookx
 
 ## History
 
-The version of this guide provided in Ubuntu MATE release 17.10 and earlier was writtten using the [Mallard](http://projectmallard.org/index.html) topic-oriented markup format. Mallard documentation consists of a set of text files for documentation presented to users with the **Yelp** help system pre-installed in Ubuntu MATE. Mallard formatting is used by several Linux applications packaged with Ubuntu MATE.
+The version of this guide provided in Ubuntu MATE release 17.10 and earlier was written using the [Mallard](http://projectmallard.org/index.html) topic-oriented markup format. Mallard documentation consists of a set of text files for documentation presented to users with the **Yelp** help system pre-installed in Ubuntu MATE. Mallard formatting is used by several Linux applications packaged with Ubuntu MATE.
 
 With Ubuntu MATE release 18.10 the documentation has been expanded significantly and now uses the *DocBook* format. *DocBook* is also a markup format for creating documentation presented to users with the **Yelp** help system, however the entire documentation is contained in a single file named `index.docbook`. This format appears to be preferred in documentation produced for applications produced by the MATE project. Although the presentation in the help system is slightly different, both the *DocBook* format and the *Mallard* format for documentation can link to one-another and interact nicely in **Yelp**.
 

--- a/index.docbook
+++ b/index.docbook
@@ -5463,12 +5463,7 @@ To report a bug or make a suggestion regarding Ubuntu MATE, its components, or t
         </imageobject>
         <textobject>Community icon.</textobject>
       </inlinemediaobject>
-      Posing your question to the Ubuntu MATE Community is the fastest and easiest way to get answers about how to use Ubuntu MATE. Join the conversation and get involved. Stop by to share your experiences, ask questions and discuss topics with other users and developers in our growing community.
-    </simpara>
-    <simpara>
-      The
-      <ulink url="https://ubuntu-mate.org/community/">Community page on the Ubuntu MATE website</ulink>
-      provides options in three categories. Community, Testimonials, and Desktop Hall of Fame.
+      Posing your question to the <ulink url="https://ubuntu-mate.org/community/">Ubuntu MATE Community</ulink> is the fastest and easiest way to get answers about how to use Ubuntu MATE. Join the conversation and get involved. Stop by to share your experiences, ask questions and discuss topics with other users and developers in our growing community.
     </simpara>
   </sect1>
   <!-- Keyboard Shortcuts =================================================== -->


### PR DESCRIPTION
Removed obsolete reference to "Hall of Fame" in the "Community" section. Fixed type in README.